### PR TITLE
Ignore changes role assignmenet scope

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -262,6 +262,10 @@ resource "azurerm_role_assignment" "msi" {
   scope                = var.managed_identities[count.index]
   role_definition_name = "Managed Identity Operator"
   principal_id         = var.service_principal.object_id
+
+  lifecycle {
+    ignore_changes = [scope]
+  }
 }
 
 # Configure cluster

--- a/main.tf
+++ b/main.tf
@@ -263,6 +263,7 @@ resource "azurerm_role_assignment" "msi" {
   role_definition_name = "Managed Identity Operator"
   principal_id         = var.service_principal.object_id
 
+  // For now ignore changes for scope because of lower/upper case issue with resourceId forces a recreate of this resource.
   lifecycle {
     ignore_changes = [scope]
   }


### PR DESCRIPTION
For now ignore changes for scope om role assignment because of lower/upper case issue with resourceId forces a recreate of resource.