### PR TITLE
remove docker_bridge_cidr from main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -158,7 +158,6 @@ resource "azurerm_kubernetes_cluster" "aks" {
     network_plugin     = "azure"
     network_policy     = "azure"
     dns_service_ip     = cidrhost(var.service_cidr, 10)
-    docker_bridge_cidr = "172.17.0.1/16"
     service_cidr       = var.service_cidr
 
     # Use Standard if availability zones are set, Basic otherwise


### PR DESCRIPTION
Parameter docker_bridge_cidr is deprecated as of April 2023. 

Required Action:
We recommend transitioning from the Docker Bridge CIDR field as it's no longer being validated. If you continue using this field in an API version after it is removed (2023-04-01 API version or later), your API request may be rejected. Furthermore, if you update to use one of the Azure SDKs released after April 2023, your code may not compile.

From https://github.com/Azure/AKS/issues/3534#:
There is no action needed other than "when you update your templates or provisioning code (ARM, Bicep, SDK clients, etc.) to use the 2023-04-01 API version, you will need to stop sending this value if you are doing so today."