### PR TITLE
OS Security Update Mechanism

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -22,21 +22,21 @@ provider "registry.terraform.io/hashicorp/azuread" {
 }
 
 provider "registry.terraform.io/hashicorp/azurerm" {
-  version     = "3.61.0"
-  constraints = "~> 3.61.0"
+  version     = "3.72.0"
+  constraints = "~> 3.72.0"
   hashes = [
-    "h1:3qOZEe76cSc1CjSn86j3ItrJk/4xv2UL/g8KkOUaWYo=",
-    "zh:1441e4e9b63801bc2432b1c06e0d202e66946c57abbf553d7f88fba5986e8f59",
-    "zh:291f0db2808724119a079f9a30254dbeae4a450dbacdd8bbb821d9332b842b25",
-    "zh:3069754dece944a9a5b2b5394e09bc393a22211951a73a1fdccc5c9fa41785d2",
-    "zh:4c6502f93da330d4b91ff2fbf198700619566386fd92c17ad14492b78a135403",
-    "zh:5f0fe6ca017b30534362e2ffcab03bcad9f08b59485948ba751248ee4b7deb7d",
-    "zh:76cdce8bb5fc73b65a21fb7eae943096397c53acda30fbe5da2892c92dabd3f9",
-    "zh:8f990887703da526d71ba25dcc259797e763397f23c3c04003c0706893db474c",
-    "zh:90854ec0570367b0d0c29e69f7426aca6dd85e6a3f8e3ed108ab5570311e587c",
-    "zh:a9450a8e1e45a577a62f252b383fe6a7159ee782a16ed8142377264b86e47fa4",
-    "zh:cc228b766a089be615e5d8b88342670a6a4cd05d44eb535232b8613c8d23218b",
-    "zh:d817088f245dce195c25492f6b2c8c26f02fd863cb5da5b689733b7c6bba3559",
+    "h1:KowUJ0RB59RdiX+K65FHOVrTURuKbMfemLJU56jnWzc=",
+    "zh:0750326f82dc0765cd9dc0e142b4c325be7918beeacc0b887510274f15d76311",
+    "zh:10ba452905de646181bfbbb9555c7b8fb96138ddc4bb42227521c402c3b12213",
+    "zh:25c8198603cffa0920e6ae39a87a5bb4af75bbe1fba36156e8077ae50261a7ca",
+    "zh:5c294fff683c2fc292f502da43f41bf4b68a20bf60a2e92723768a0ce7fe2c7a",
+    "zh:84449a0e7d5bd4a3fda9a4c9ad287c4c7ebcc5ede406d3ab7593f073d40abdfc",
+    "zh:89f3fc2b3e84e45776fce547ed9fa3dbdba65fe243094fe308c5cef273b4d980",
+    "zh:a8cdfc816fbf14a230c3bb4ccdf70d19069186de78008e49dc9dfaa8aaf0208e",
+    "zh:d6e1d86f2d6d0e09d3961f10f9e26e24a25d39e98ecaf93d5cb089ddb4fea5b6",
+    "zh:e74f0e6c3904da8ff10bdb90be1fd8b20f1d3f14d62d24ffb76b61c623ee0e3c",
+    "zh:e9fb32ef48450b8109e30e47280053ca7d5307190bf6f516e1bebaf556dc8d81",
+    "zh:ee8c9bb7aa318a3d8a313eb032b3fc1a332114fe112723ba7b0c8cb4a5947476",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ module "simple" {
   location                = "westeurope"
   service_cidr            = "10.0.0.0/24"
   kubernetes_version      = "1.15.5"
-  node_os_channel_upgrade = "SecurityPatch"
 
   agent_pools = [
     {

--- a/README.md
+++ b/README.md
@@ -19,13 +19,14 @@ This example deploys a simple cluster with one node pool.
 ```terraform
 module "simple" {
   source  = "avinor/kubernetes/azurerm"
-  version = "5.0.0"
+  version = "5.2.1"
 
-  name                = "simple"
-  resource_group_name = "simple-aks-rg"
-  location            = "westeurope"
-  service_cidr        = "10.0.0.0/24"
-  kubernetes_version  = "1.15.5"
+  name                    = "simple"
+  resource_group_name     = "simple-aks-rg"
+  location                = "westeurope"
+  service_cidr            = "10.0.0.0/24"
+  kubernetes_version      = "1.15.5"
+  node_os_channel_upgrade = "SecurityPatch"
 
   agent_pools = [
     {

--- a/examples/addons/main.tf
+++ b/examples/addons/main.tf
@@ -6,7 +6,6 @@ module "addon" {
   location                = "westeurope"
   service_cidr            = "10.241.0.0/24"
   kubernetes_version      = "1.23.8"
-  node_os_channel_upgrade = "SecurityPatch"
 
   agent_pools = [
     {

--- a/examples/addons/main.tf
+++ b/examples/addons/main.tf
@@ -1,11 +1,12 @@
 module "addon" {
   source = "../../"
 
-  name                = "addons"
-  resource_group_name = "addons-aks-rg"
-  location            = "westeurope"
-  service_cidr        = "10.241.0.0/24"
-  kubernetes_version  = "1.23.8"
+  name                    = "addons"
+  resource_group_name     = "addons-aks-rg"
+  location                = "westeurope"
+  service_cidr            = "10.241.0.0/24"
+  kubernetes_version      = "1.23.8"
+  node_os_channel_upgrade = "SecurityPatch"
 
   agent_pools = [
     {

--- a/examples/diagnostics/main.tf
+++ b/examples/diagnostics/main.tf
@@ -1,11 +1,12 @@
 module "diagnostics" {
   source = "../../"
 
-  name                = "diagnostics"
-  resource_group_name = "diagnostics-aks-rg"
-  location            = "westeurope"
-  service_cidr        = "10.241.0.0/24"
-  kubernetes_version  = "1.18.14"
+  name                    = "diagnostics"
+  resource_group_name     = "diagnostics-aks-rg"
+  location                = "westeurope"
+  service_cidr            = "10.241.0.0/24"
+  kubernetes_version      = "1.18.14"
+  node_os_channel_upgrade = "SecurityPatch"
 
   agent_pools = [
     {

--- a/examples/diagnostics/main.tf
+++ b/examples/diagnostics/main.tf
@@ -6,7 +6,6 @@ module "diagnostics" {
   location                = "westeurope"
   service_cidr            = "10.241.0.0/24"
   kubernetes_version      = "1.18.14"
-  node_os_channel_upgrade = "SecurityPatch"
 
   agent_pools = [
     {

--- a/examples/rbac/main.tf
+++ b/examples/rbac/main.tf
@@ -7,7 +7,6 @@ module "rbac" {
   service_cidr            = "10.241.0.0/24"
   kubernetes_version      = "1.18.14"
   azure_rbac_enabled      = true
-  node_os_channel_upgrade = "SecurityPatch"
 
   agent_pools = [
     {

--- a/examples/rbac/main.tf
+++ b/examples/rbac/main.tf
@@ -1,12 +1,13 @@
 module "rbac" {
   source = "../../"
 
-  name                = "rbac"
-  resource_group_name = "rbac-aks-rg"
-  location            = "norwayeast"
-  service_cidr        = "10.241.0.0/24"
-  kubernetes_version  = "1.18.14"
-  azure_rbac_enabled  = true
+  name                    = "rbac"
+  resource_group_name     = "rbac-aks-rg"
+  location                = "norwayeast"
+  service_cidr            = "10.241.0.0/24"
+  kubernetes_version      = "1.18.14"
+  azure_rbac_enabled      = true
+  node_os_channel_upgrade = "SecurityPatch"
 
   agent_pools = [
     {

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,11 +1,12 @@
 module "simple" {
   source = "../../"
 
-  name                = "simple"
-  resource_group_name = "simple-aks-rg"
-  location            = "westeurope"
-  service_cidr        = "10.241.0.0/24"
-  kubernetes_version  = "1.18.14"
+  name                    = "simple"
+  resource_group_name     = "simple-aks-rg"
+  location                = "westeurope"
+  service_cidr            = "10.241.0.0/24"
+  kubernetes_version      = "1.18.14"
+  node_os_channel_upgrade = "SecurityPatch"
 
   agent_pools = [
     {

--- a/examples/upgrade/main.tf
+++ b/examples/upgrade/main.tf
@@ -1,11 +1,20 @@
-module "simple" {
+module "upgrade" {
   source = "../../"
 
-  name                    = "simple"
-  resource_group_name     = "simple-aks-rg"
+  name                    = "upgrade"
+  resource_group_name     = "upgrade-aks-rg"
   location                = "westeurope"
   service_cidr            = "10.241.0.0/24"
   kubernetes_version      = "1.18.14"
+  node_os_channel_upgrade = "Unmanaged"
+
+  maintenance_window_node_os = {
+    frequency   = "Weekly"
+    interval    = 1
+    duration    = 4
+    day_of_week = "Sunday"
+    start_time  = "01:00"
+  }
 
   agent_pools = [
     {

--- a/main.tf
+++ b/main.tf
@@ -100,11 +100,22 @@ resource "azurerm_kubernetes_cluster" "aks" {
   resource_group_name               = azurerm_resource_group.aks.name
   dns_prefix                        = var.name
   kubernetes_version                = var.kubernetes_version
-  api_server_authorized_ip_ranges   = var.api_server_authorized_ip_ranges
   node_resource_group               = var.node_resource_group
   azure_policy_enabled              = var.azure_policy_enabled
+  node_os_channel_upgrade           = var.node_os_channel_upgrade
   role_based_access_control_enabled = true
   tags                              = var.tags
+
+  dynamic "maintenance_window_node_os" {
+    for_each = var.maintenance_window_node_os != null ? [1] : []
+    content {
+      frequency   = var.maintenance_window_node_os.frequency
+      interval    = var.maintenance_window_node_os.interval
+      duration    = var.maintenance_window_node_os.duration
+      day_of_week = var.maintenance_window_node_os.day_of_week
+      start_time  = var.maintenance_window_node_os.start_time
+    }
+  }
 
   dynamic "default_node_pool" {
     for_each = { for k, v in local.agent_pools : k => v if k == local.default_pool }

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ terraform {
     }
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.61.0"
+      version = "~> 3.72.0"
     }
     azuread = {
       source  = "hashicorp/azuread"

--- a/test/example_ut_test.go
+++ b/test/example_ut_test.go
@@ -14,6 +14,7 @@ func TestUT_Examples(t *testing.T) {
 		"../examples/diagnostics",
 		"../examples/addons",
 		"../examples/rbac",
+		"../examples/upgrade",
 	}
 
 	for _, test := range tests {

--- a/variables.tf
+++ b/variables.tf
@@ -20,14 +20,15 @@ variable "kubernetes_version" {
 
 variable "node_os_channel_upgrade" {
   description = "The upgrade channel for this Kubernetes Cluster Nodes' OS Image."
+  default     = "None"
 }
 
 variable "maintenance_window_node_os" {
   description = "Maintenance window of node os upgrades."
   type = object({
     frequency   = optional(string)
-    interval    = optional(string)
-    duration    = optional(string)
+    interval    = optional(number)
+    duration    = optional(number)
     day_of_week = optional(string)
     start_time  = optional(string)
   })

--- a/variables.tf
+++ b/variables.tf
@@ -20,7 +20,7 @@ variable "kubernetes_version" {
 
 variable "node_os_channel_upgrade" {
   description = "The upgrade channel for this Kubernetes Cluster Nodes' OS Image."
-  default     = "None"
+  default     = "Unmanaged"
 }
 
 variable "maintenance_window_node_os" {
@@ -29,10 +29,15 @@ variable "maintenance_window_node_os" {
     frequency   = optional(string)
     interval    = optional(number)
     duration    = optional(number)
-    day_of_week = optional(string)
+    day_of_week = optional(string)  # Required if frequency is weekly.
     start_time  = optional(string)
   })
-  default = null
+  default = {
+    frequency   = "Daily"
+    interval    = 1
+    duration    = 4
+    start_time  = "00:00" # UTC
+  }
 }
 
 variable "node_resource_group" {

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,22 @@ variable "kubernetes_version" {
   description = "Version of Kubernetes to deploy."
 }
 
+variable "node_os_channel_upgrade" {
+  description = "The upgrade channel for this Kubernetes Cluster Nodes' OS Image."
+}
+
+variable "maintenance_window_node_os" {
+  description = "Maintenance window of node os upgrades."
+  type = object({
+    frequency   = optional(string)
+    interval    = optional(string)
+    duration    = optional(string)
+    day_of_week = optional(string)
+    start_time  = optional(string)
+  })
+  default = null
+}
+
 variable "node_resource_group" {
   description = "The name of the Resource Group where the Kubernetes Nodes should exist."
   default     = null
@@ -26,12 +42,6 @@ variable "node_resource_group" {
 variable "agent_pools" {
   description = "A list of agent pools to create, each item supports same properties as `agent_pool_profile`. See README for default values."
   type        = list(any)
-}
-
-variable "api_server_authorized_ip_ranges" {
-  description = "The IP ranges to whitelist for incoming traffic to the masters."
-  type        = list(string)
-  default     = null
 }
 
 variable "linux_profile" {


### PR DESCRIPTION
Changes:
- Upgrades azurerm to 3.72.0.
- Adds support for node os security update mechanism through the `node_os_channel_upgrade` variable. The options are either `Unmanaged`, `SecurityPatch`, `NodeImage` or `None`. The module defaults to `Unmanaged`.
- Adds support for specifying node os maintenance window through the `maintenance_window_node_os` variable and is optional. The module defaults to a `Daily` frequency at `00:00 UTC` with a duration of `4` hours.
- Removes the implementation of `api_server_authorized_ip_ranges` as it is deprecated and unused. 

Documentation on node OS auto-upgrade options found here: https://learn.microsoft.com/en-us/azure/aks/auto-upgrade-node-image.