### PR TITLE
[kubernetes] change upgrade & maintenance default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ This example deploys a simple cluster with one node pool.
 ```terraform
 module "simple" {
   source  = "avinor/kubernetes/azurerm"
-  version = "6.0.0"
+  version = "6.0.1"
 
   name                    = "simple"
   resource_group_name     = "simple-aks-rg"
   location                = "westeurope"
   service_cidr            = "10.0.0.0/24"
-  kubernetes_version      = "1.15.5"
+  kubernetes_version      = "1.27.6"
 
   agent_pools = [
     {

--- a/examples/upgrade/main.tf
+++ b/examples/upgrade/main.tf
@@ -6,15 +6,7 @@ module "upgrade" {
   location                = "westeurope"
   service_cidr            = "10.241.0.0/24"
   kubernetes_version      = "1.18.14"
-  node_os_channel_upgrade = "Unmanaged"
-
-  maintenance_window_node_os = {
-    frequency   = "Weekly"
-    interval    = 1
-    duration    = 4
-    day_of_week = "Sunday"
-    start_time  = "01:00"
-  }
+  node_os_channel_upgrade = "NodeImage"
 
   agent_pools = [
     {

--- a/variables.tf
+++ b/variables.tf
@@ -20,7 +20,7 @@ variable "kubernetes_version" {
 
 variable "node_os_channel_upgrade" {
   description = "The upgrade channel for this Kubernetes Cluster Nodes' OS Image."
-  default     = "Unmanaged"
+  default     = "NodeImage"
 }
 
 variable "maintenance_window_node_os" {
@@ -32,12 +32,7 @@ variable "maintenance_window_node_os" {
     day_of_week = optional(string) # Required if frequency is weekly.
     start_time  = optional(string)
   })
-  default = {
-    frequency  = "Daily"
-    interval   = 1
-    duration   = 4
-    start_time = "00:00" # UTC
-  }
+  default = null
 }
 
 variable "node_resource_group" {


### PR DESCRIPTION
Fixing an issue with azurerm when updating existing maintenance window for Azure Kubernetes Service (AKS).

The issue occurs when running the terraform apply command, specifically when the computed window start time falls in the past.

The key point of this issue is that the logic to calculate the window start date doesn't seem to consider the current time, thereby allowing a past date to be used where only future dates should be valid. 

Reference: 
https://github.com/hashicorp/terraform-provider-azurerm/issues/22762